### PR TITLE
Fix CRLF default for serial data

### DIFF
--- a/js/serial.js
+++ b/js/serial.js
@@ -117,7 +117,7 @@ function displayData(data) {
         const writer = port.writable.getWriter();
     
         try {
-            const eolOption = "clrf";
+            const eolOption = "crlf";
             let formattedData = typeof data === 'string' ? data : '';
             
             switch (eolOption) {


### PR DESCRIPTION
## Summary
- correct typo in serial.js so `crlf` works correctly

## Testing
- `./script/build` *(fails: npm 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848c7c30ba08327bff1d58bba448179